### PR TITLE
Fix OT credentials validation

### DIFF
--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -35,9 +35,8 @@ const checkRole = (role, req, res, next) => {
 const validateApiKey = (req, res, next) => {
   const { otApiKey, otSecret } = req.body;
   if (otApiKey || otSecret) {
-    opentok.createSession(otApiKey, otSecret, false)
-    .then(() => next())
-    .catch(R.partial(sendError, [res, 'Invalid APIKey or APISecret']));
+    const ot = opentok.createOTInstance(otApiKey, otSecret);
+    ot.createSession(err => (err ? sendError(res, 'Invalid APIKey or APISecret') : next()));
   } else {
     next();
   }

--- a/server/services/opentok.js
+++ b/server/services/opentok.js
@@ -16,6 +16,22 @@ const testPortal = false;
 const defaultSessionOptions = { mediaMode: 'routed' };
 
 /**
+ * Create the OT instance for a project (apiKey)
+ * @param {String} apiKey
+ * @param {String} apiSecret
+ */
+const createOTInstance = (apiKey, apiSecret) => {
+  const tbrelUrl = 'https://anvil-tbrel.opentok.com';
+  return !testPortal ?
+    new OpenTok(apiKey, apiSecret) :
+    R.assocPath(
+      ['_client', 'c', 'apiUrl'],
+      tbrelUrl,
+      R.assoc('apiUrl', tbrelUrl, new OpenTok(apiKey, apiSecret)) // eslint-disable-line comma-dangle
+    );
+};
+
+/**
  * Get the OT instance for a project (apiKey)
  * @param {String} apiKey
  * @param {String} apiSecret
@@ -24,14 +40,7 @@ const defaultSessionOptions = { mediaMode: 'routed' };
 const otInstance = (apiKey, apiSecret, descryptSecret = true) => {
   if (OT[apiKey]) { return OT[apiKey]; }
   const secret = descryptSecret ? decrypt(apiSecret) : apiSecret;
-  const tbrelUrl = 'https://anvil-tbrel.opentok.com';
-  const ot = !testPortal ?
-    new OpenTok(apiKey, secret) :
-    R.assocPath(
-      ['_client', 'c', 'apiUrl'],
-      tbrelUrl,
-      R.assoc('apiUrl', tbrelUrl, new OpenTok(apiKey, secret)) // eslint-disable-line comma-dangle
-    );
+  const ot = createOTInstance(apiKey, secret);
   OT[apiKey] = ot;
   return ot;
 };
@@ -105,6 +114,7 @@ const otRoles = {
 };
 
 module.exports = {
+  createOTInstance,
   createSession,
   createToken,
   startArchive,


### PR DESCRIPTION
This PR fixes the OT credentials validation.
Before we were using the global OT object for creating sessions. That's fine but when we just need to validate an APIKey and Secret, we need to create the OT instance, and not reuse the previous one.

